### PR TITLE
Fix index error after weight broadcast optimization

### DIFF
--- a/megatron/core/dist_checkpointing/exchange_utils.py
+++ b/megatron/core/dist_checkpointing/exchange_utils.py
@@ -550,7 +550,6 @@ def exchange_loaded_tensors_broadcast(
                         all_loaded_tensors[shard_id] = batch_tensors[i].to(orig_device, non_blocking=True)
                 else:
                     all_loaded_tensors[shard_id] = batch_tensors[i].to(orig_device)
-            del batch_tensors[i]
         
         # Synchronize streams after D2H copies
         if streams:


### PR DESCRIPTION
Remove redundant `del batch_tensors[i]` to fix `IndexError` caused by modifying a list during iteration after the weight broadcast optimization.

The previous PR introduced an optimization for weight broadcast. Following this, an `IndexError` occurred in `exchange_utils.py` because `del batch_tensors[i]` was attempting to delete elements from `batch_tensors` within a forward loop. This operation shifts indices, leading to the `IndexError`. This line was also redundant as the entire `batch_tensors` list is deleted later, so removing it resolves the bug without affecting memory cleanup.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a7b3dac-8977-409f-991b-7ae835191c65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0a7b3dac-8977-409f-991b-7ae835191c65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

